### PR TITLE
Support arbitrary file names

### DIFF
--- a/src/keystore.rs
+++ b/src/keystore.rs
@@ -1,13 +1,12 @@
 use hex::{FromHex, ToHex};
 use serde::{de::Deserializer, ser::Serializer, Deserialize, Serialize};
-use uuid::Uuid;
 
 #[derive(Debug, Deserialize, Serialize)]
 /// This struct represents the deserialized form of an encrypted JSON keystore based on the
 /// [Web3 Secret Storage Definition](https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition).
 pub struct EthKeystore {
     pub crypto: CryptoJson,
-    pub id: Uuid,
+    pub id: String,
     pub version: u8,
 }
 
@@ -79,6 +78,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use uuid::Uuid;
     use super::*;
 
     #[test]
@@ -107,7 +107,7 @@ mod tests {
         assert_eq!(keystore.version, 3);
         assert_eq!(
             keystore.id,
-            Uuid::parse_str("3198bc9c-6672-5ab3-d995-4942343ae5b6").unwrap()
+            Uuid::parse_str("3198bc9c-6672-5ab3-d995-4942343ae5b6").unwrap().to_string()
         );
         assert_eq!(keystore.crypto.cipher, "aes-128-ctr");
         assert_eq!(
@@ -166,7 +166,7 @@ mod tests {
         assert_eq!(keystore.version, 3);
         assert_eq!(
             keystore.id,
-            Uuid::parse_str("3198bc9c-6672-5ab3-d995-4942343ae5b6").unwrap()
+            Uuid::parse_str("3198bc9c-6672-5ab3-d995-4942343ae5b6").unwrap().to_string()
         );
         assert_eq!(keystore.crypto.cipher, "aes-128-ctr");
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ where
     let mut pk = vec![0u8; DEFAULT_KEY_SIZE];
     rng.fill_bytes(pk.as_mut_slice());
 
-    let uuid = encrypt_key(dir, rng, pk.clone(), password, None)?;
+    let uuid = encrypt_key(dir, rng, pk.clone(), password, None::<String>)?;
     Ok((pk, uuid))
 }
 
@@ -161,24 +161,26 @@ where
 /// let mut private_key = vec![0u8; 32];
 /// rng.fill_bytes(private_key.as_mut_slice());
 ///
-/// let uuid = encrypt_key(&dir, &mut rng, &private_key, "password_to_keystore", None)?;
+/// let uuid = encrypt_key(&dir, &mut rng, &private_key, "password_to_keystore", None::<String>)?;
 /// # Ok(())
 /// # }
 /// ```
-pub fn encrypt_key<P, R, B, S>(
+pub fn encrypt_key<P, R, B, S, I>(
     dir: P,
     rng: &mut R,
     pk: B,
     password: S,
-    mut id: Option<String>,
+    id: Option<I>,
 ) -> Result<String, KeystoreError>
 where
     P: AsRef<Path>,
     R: Rng + CryptoRng,
     B: AsRef<[u8]>,
     S: AsRef<[u8]>,
+    I: Into<String>,
 {
-    let id = id.take().unwrap_or(Uuid::new_v4().to_string());
+    let id = id.map(|id| id.into())
+        .unwrap_or(Uuid::new_v4().to_string());
     // Generate a random salt.
     let mut salt = vec![0u8; DEFAULT_KEY_SIZE];
     rng.fill_bytes(salt.as_mut_slice());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,10 @@ where
     Ok(pk)
 }
 
-#[deprecated(note = "Use encrypt_key_with_id() instead")]
+/// Encrypts the given private key using the [Scrypt](https://tools.ietf.org/html/rfc7914.html)
+/// password-based key derivation function, and stores 
+/// it in the provided directory using a UUID (v4)
+/// for the identifier.
 pub fn encrypt_key<P, R, B, S>(
     dir: P,
     rng: &mut R,
@@ -159,8 +162,9 @@ where
 }
 
 /// Encrypts the given private key using the [Scrypt](https://tools.ietf.org/html/rfc7914.html)
-/// password-based key derivation function, and stores it in the provided directory using the
-/// identifier as the file name.
+/// password-based key derivation function, and stores 
+/// it in the provided directory using the
+/// given identifier as the file name.
 ///
 /// # Example
 ///

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -48,7 +48,7 @@ mod tests {
                 .unwrap();
         let dir = Path::new("./tests/test-keys");
         let mut rng = rand::thread_rng();
-        let uuid = encrypt_key(&dir, &mut rng, &secret, "newpassword").unwrap();
+        let uuid = encrypt_key(&dir, &mut rng, &secret, "newpassword", None).unwrap();
 
         let keypath = dir.join(uuid);
         assert_eq!(decrypt_key(&keypath, "newpassword").unwrap(), secret);

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -7,18 +7,16 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let dir = Path::new("./tests/test-keys");
+        let file = Path::new("./target/test_new.json");
         let mut rng = rand::thread_rng();
-        let (secret, uuid) = new(&dir, &mut rng, "thebestrandompassword").unwrap();
-
-        let keypath = dir.join(uuid);
+        let (secret, _uuid) = new(&file, &mut rng, "thebestrandompassword").unwrap();
 
         assert_eq!(
-            decrypt_key(&keypath, "thebestrandompassword").unwrap(),
+            decrypt_key(&file, "thebestrandompassword").unwrap(),
             secret
         );
-        assert!(decrypt_key(&keypath, "notthebestrandompassword").is_err());
-        assert!(std::fs::remove_file(&keypath).is_ok());
+        assert!(decrypt_key(&file, "notthebestrandompassword").is_err());
+        assert!(std::fs::remove_file(&file).is_ok());
     }
 
     #[test]
@@ -46,13 +44,12 @@ mod tests {
         let secret =
             Vec::from_hex("7a28b5ba57c53603b0b07b56bba752f7784bf506fa95edc395f5cf6c7514fe9d")
                 .unwrap();
-        let dir = Path::new("./tests/test-keys");
+        let file = Path::new("./target/test_encrypt_decrypt_key.json");
         let mut rng = rand::thread_rng();
-        let uuid = encrypt_key(&dir, &mut rng, &secret, "newpassword", None::<String>).unwrap();
+        let _uuid = encrypt_key(&file, &mut rng, &secret, "newpassword").unwrap();
 
-        let keypath = dir.join(uuid);
-        assert_eq!(decrypt_key(&keypath, "newpassword").unwrap(), secret);
-        assert!(decrypt_key(&keypath, "notanewpassword").is_err());
-        assert!(std::fs::remove_file(&keypath).is_ok());
+        assert_eq!(decrypt_key(&file, "newpassword").unwrap(), secret);
+        assert!(decrypt_key(&file, "notanewpassword").is_err());
+        assert!(std::fs::remove_file(&file).is_ok());
     }
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -48,7 +48,7 @@ mod tests {
                 .unwrap();
         let dir = Path::new("./tests/test-keys");
         let mut rng = rand::thread_rng();
-        let uuid = encrypt_key(&dir, &mut rng, &secret, "newpassword", None).unwrap();
+        let uuid = encrypt_key(&dir, &mut rng, &secret, "newpassword", None::<String>).unwrap();
 
         let keypath = dir.join(uuid);
         assert_eq!(decrypt_key(&keypath, "newpassword").unwrap(), secret);


### PR DESCRIPTION
Add `encrypt_key_with_id()`; deprecate `encrypt_key()`.

I have done this so it is backwards compatible and deprecates the previous signature, hope that is ok.

If you prefer to make it a breaking change, thats cool with me too, we could just bump the minor version.

Closes #7.